### PR TITLE
Refactor command builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-jq",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Run jq in node",
   "main": "lib/jq.js",
   "repository": "https://github.com/davesnx/node-jq",

--- a/src/jq.js
+++ b/src/jq.js
@@ -33,16 +33,29 @@ const validateJsonPath = (json) => {
 
 const runJqNullInput = (filter, json) => {
   return new Promise((resolve, reject) => {
-    execa(`jq --null-input '${json} | ${filter}`)
-    .then(resolve)
+    execa(
+      'jq',
+      [
+        '--null-input',
+        `${filter} | ${JSON.stringify(json)}`
+      ]
+    )
+    .then(({ stdout }) => {
+      resolve(JSON.parse(stdout))
+    })
     .catch(reject)
   })
 }
 
 const runJq = (filter, jsonPath) => {
   return new Promise((resolve, reject) => {
-    execa('jq', [filter, jsonPath])
-    .then(resolve)
+    execa(
+      'jq',
+      [filter, jsonPath]
+    )
+    .then(({ stdout }) => {
+      resolve(JSON.parse(stdout))
+    })
     .catch(reject)
   })
 }

--- a/src/jq.js
+++ b/src/jq.js
@@ -31,28 +31,33 @@ const validateJsonPath = (json) => {
   return json
 }
 
-const runJqNullInput = (filter, json) => {
-  return new Promise((resolve, reject) => {
-    execa(
-      'jq',
-      [
-        '--null-input',
-        `${filter} | ${JSON.stringify(json)}`
-      ]
-    )
-    .then(({ stdout }) => {
-      resolve(JSON.parse(stdout))
-    })
-    .catch(reject)
-  })
+const buildNullInputParams = (filter, json) => {
+  return [
+    '--null-input',
+    `${filter} | ${JSON.stringify(json)}`
+  ]
 }
 
-const runJq = (filter, jsonPath) => {
+const createJqCommand = (filter, json, options = {}) => {
+  const command = {
+    cmd: 'jq',
+    params: []
+  }
+
+  if (options.nullInput === true) {
+    command.params = buildNullInputParams(filter, json)
+  } else {
+    validateJsonPath(json)
+    command.params = [filter, json]
+  }
+
+  return command
+}
+
+const runJq = (filter, json, options) => {
   return new Promise((resolve, reject) => {
-    execa(
-      'jq',
-      [filter, jsonPath]
-    )
+    const { cmd, params } = createJqCommand(filter, json, options)
+    execa(cmd, params)
     .then(({ stdout }) => {
       resolve(JSON.parse(stdout))
     })
@@ -62,11 +67,6 @@ const runJq = (filter, jsonPath) => {
 
 export const run = (filter, json, options = {}) => {
   return new Promise((resolve, reject) => {
-    if (options.nullInput === true) {
-      runJqNullInput(filter, json).then(resolve).catch(reject)
-    } else {
-      const jsonPath = validateJsonPath(json)
-      runJq(filter, jsonPath).then(resolve).catch(reject)
-    }
+    runJq(filter, json, options).then(resolve).catch(reject)
   })
 }

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -68,4 +68,20 @@ describe('jq runs a cli', () => {
       'Isn`t a JSON'
     )
   })
+
+  it('should run the filter inline with null-input', (done) => {
+    const jsonFixtureToString = JSON.stringify(jsonFixture)
+    run(
+      '.',
+      jsonFixtureToString,
+      { nullInput: true }
+    )
+    .then((result) => {
+      expect(result).to.be.equal(jsonFixtureToString)
+      done()
+    })
+    .catch((err) => {
+      done(err)
+    })
+  })
 })


### PR DESCRIPTION
I came up with some idea for create the options map:

```js
const optionsMap = [
  {
    nullInput: {
      flag: '--null-input',
      buildParams: (filter, json) => {
        return [
          '--null-input',
          `${filter} | ${JSON.stringify(json)}`
        ]
      }
    }
    // [...]
  }
]
```

I didn't implemet it yet, because I only have 1 option and I want to know if this make sense in the jq parameters. 

This PR it's just the first approach that I made, after the duplicity that in master exist.

Solves this: https://github.com/davesnx/node-jq/issues/1