### PR TITLE
Refactor utils and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-jq",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Run jq in node",
   "main": "lib/jq.js",
   "repository": "https://github.com/davesnx/node-jq",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     ]
   },
   "standard": {
-    "globals": [
+    "global": [
       "describe",
       "it"
     ]

--- a/src/jq.js
+++ b/src/jq.js
@@ -33,16 +33,29 @@ const validateJsonPath = (json) => {
 
 const runJqNullInput = (filter, json) => {
   return new Promise((resolve, reject) => {
-    execa(`jq --null-input '${json} | ${filter}`)
-    .then(resolve)
+    execa(
+      'jq',
+      [
+        '--null-input',
+        `${filter} | ${JSON.stringify(json)}`
+      ]
+    )
+    .then(({ stdout }) => {
+      resolve(JSON.parse(stdout))
+    })
     .catch(reject)
   })
 }
 
 const runJq = (filter, jsonPath) => {
   return new Promise((resolve, reject) => {
-    execa('jq', [filter, jsonPath])
-    .then(resolve)
+    execa(
+      'jq',
+      [filter, jsonPath]
+    )
+    .then(({ stdout }) => {
+      resolve(JSON.parse(stdout))
+    })
     .catch(reject)
   })
 }

--- a/src/jq.js
+++ b/src/jq.js
@@ -31,28 +31,33 @@ const validateJsonPath = (json) => {
   return json
 }
 
-const runJqNullInput = (filter, json) => {
-  return new Promise((resolve, reject) => {
-    execa(
-      'jq',
-      [
-        '--null-input',
-        `${filter} | ${JSON.stringify(json)}`
-      ]
-    )
-    .then(({ stdout }) => {
-      resolve(JSON.parse(stdout))
-    })
-    .catch(reject)
-  })
+const buildNullInputParams = (filter, json) => {
+  return [
+    '--null-input',
+    `${filter} | ${JSON.stringify(json)}`
+  ]
 }
 
-const runJq = (filter, jsonPath) => {
+const createJqCommand = (filter, json, options = {}) => {
+  const command = {
+    cmd: 'jq',
+    params: []
+  }
+
+  if (options.nullInput === true) {
+    command.params = buildNullInputParams(filter, json)
+  } else {
+    validateJsonPath(json)
+    command.params = [filter, json]
+  }
+
+  return command
+}
+
+const runJq = (filter, json, options) => {
   return new Promise((resolve, reject) => {
-    execa(
-      'jq',
-      [filter, jsonPath]
-    )
+    const { cmd, params } = createJqCommand(filter, json, options)
+    execa(cmd, params)
     .then(({ stdout }) => {
       resolve(JSON.parse(stdout))
     })
@@ -62,11 +67,6 @@ const runJq = (filter, jsonPath) => {
 
 export const run = (filter, json, options = {}) => {
   return new Promise((resolve, reject) => {
-    if (options.nullInput === true) {
-      runJqNullInput(filter, json).then(resolve).catch(reject)
-    } else {
-      const jsonPath = validateJsonPath(json)
-      runJq(filter, jsonPath).then(resolve).catch(reject)
-    }
+    runJq(filter, json, options).then(resolve).catch(reject)
   })
 }

--- a/src/jq.js
+++ b/src/jq.js
@@ -1,35 +1,5 @@
 import execa from 'execa'
-import isPathValid from 'is-valid-path'
-
-export const isAJsonPath = (path) => {
-  return /\.json$/.test(path)
-}
-
-export const isAJson = (json) => {
-  try {
-    JSON.parse(json)
-  } catch (e) {
-    return false
-  }
-  return true
-}
-
-const validateJsonPath = (json) => {
-  if (isPathValid(json)) {
-    if (typeof json !== 'string') {
-      json = json.toString()
-    }
-
-    if (!isPathValid(json)) {
-      if (!isAJsonPath(json)) {
-        throw (Error('Isn`t a JSON'))
-      }
-      throw (Error('Is a invalid path'))
-    }
-  }
-
-  return json
-}
+import { validateJsonPath } from './utils'
 
 const buildNullInputParams = (filter, json) => {
   return [

--- a/src/utils.js
+++ b/src/utils.js
@@ -20,17 +20,7 @@ export const validateJsonPath = (jsonPath) => {
     throw (Error('Is a invalid path'))
   }
 
-  if (!isAJson(jsonPath)) {
+  if (!isAJsonPath(jsonPath)) {
     throw (Error('Is not a JSON file'))
   }
 }
-
-// FIXME: (?)
-// export const validateJsonPath = (json) => {
-//   if (!isPathValid(json)) {
-//     if (!isAJsonPath(json)) {
-//       throw (Error('Isn`t a JSON'))
-//     }
-//     throw (Error('Is a invalid path'))
-//   }
-// }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,36 @@
+import isPathValid from 'is-valid-path'
+
+export const isAJsonPath = (path) => {
+  return /\.json$/.test(path)
+}
+
+// FIXME: JSON.parse is so slow
+//        we could access the first key of the object
+export const isAJson = (json) => {
+  try {
+    JSON.parse(json)
+  } catch (e) {
+    return false
+  }
+  return true
+}
+
+export const validateJsonPath = (jsonPath) => {
+  if (!isPathValid(jsonPath) || !isAJsonPath(jsonPath)) {
+    throw (Error('Is a invalid path'))
+  }
+
+  if (!isAJson(jsonPath)) {
+    throw (Error('Is not a JSON file'))
+  }
+}
+
+// FIXME: (?)
+// export const validateJsonPath = (json) => {
+//   if (!isPathValid(json)) {
+//     if (!isAJsonPath(json)) {
+//       throw (Error('Isn`t a JSON'))
+//     }
+//     throw (Error('Is a invalid path'))
+//   }
+// }

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -68,4 +68,20 @@ describe('jq runs a cli', () => {
       'Isn`t a JSON'
     )
   })
+
+  it('should run the filter inline with null-input', (done) => {
+    const jsonFixtureToString = JSON.stringify(jsonFixture)
+    run(
+      '.',
+      jsonFixtureToString,
+      { nullInput: true }
+    )
+    .then((result) => {
+      expect(result).to.be.equal(jsonFixtureToString)
+      done()
+    })
+    .catch((err) => {
+      done(err)
+    })
+  })
 })

--- a/test/jq.test.js
+++ b/test/jq.test.js
@@ -1,87 +1,46 @@
-import chai, { expect, assert } from 'chai'
+import chai, { expect } from 'chai'
 import chaiAsPromised from 'chai-as-promised'
 chai.use(chaiAsPromised)
-import { run, isAJson, isAJsonPath } from '../src/jq'
+import { run } from '../src/jq'
 import path from 'path'
 import jsonFixture from './fixtures/1.json'
 
+const jsonFixtureToString = JSON.stringify(jsonFixture)
 const FIXTURES_PATH = path.join(__dirname, 'fixtures')
 const ROOT_PATH = path.join(__dirname, '..')
 const jsonPathFixture = path.join(FIXTURES_PATH, '1.json')
 const jsPathFixture = path.join(FIXTURES_PATH, '1.js')
+const asteriskPathFixture = path.join(ROOT_PATH, 'src', '*.js')
 const filter = '. | map(select(.a == .id))'
 
-describe('path', () => {
-  describe('#isAJsonPath', () => {
-    it('should return true when u give a jsonpath', () => {
-      expect(isAJsonPath(jsonPathFixture)).to.be.equal(true)
-    })
-
-    it('should return false when u give a non-jsonpath', () => {
-      expect(isAJsonPath(jsPathFixture)).to.be.equal(false)
-    })
-  })
-
-  describe('#isAJson', () => {
-    it('should return true when u give a json', () => {
-      const jsonStringifiedFixture = JSON.stringify(jsonFixture)
-      expect(isAJson(jsonStringifiedFixture)).to.be.equal(true)
-    })
-
-    it('should return false when u give a non-json', () => {
-      expect(isAJson('lola')).to.be.equal(false)
-    })
-  })
-})
-
 describe('jq runs a cli', () => {
-  it('should return a stdout object', (done) => {
-    run(filter, jsonPathFixture)
-      .then((result) => {
-        expect(result).to.be.instanceof(Object)
-        done()
-      })
-      .catch((err) => {
-        done(err)
-      })
+  it('should return a stdout object', () => {
+    return expect(
+      run(filter, jsonPathFixture)
+    ).to.eventually.be.instanceof(Object)
   })
 
   it('should fail on a non valid filter', () => {
-    return assert.isRejected(
-      run('lola', jsonPathFixture),
-      Error
-    )
+    return expect(
+      run('lola', jsonPathFixture)
+    ).to.eventually.be.rejectedWith(Error)
   })
 
   it('should fail on a non valid path', () => {
-    return assert.isRejected(
-      run(filter, path.join(ROOT_PATH, 'src', '*.js')),
-      Error,
-      'Is a invalid path'
-    )
+    return expect(
+      run(filter, asteriskPathFixture)
+    ).to.eventually.be.rejectedWith(Error)
   })
 
   it('should fail on a non valid json', () => {
-    return assert.isRejected(
-      run(filter, path.join(ROOT_PATH, 'src', 'js.js')),
-      Error,
-      'Isn`t a JSON'
-    )
+    return expect(
+      run(filter, jsPathFixture)
+    ).to.eventually.be.rejectedWith(Error)
   })
 
-  it('should run the filter inline with null-input', (done) => {
-    const jsonFixtureToString = JSON.stringify(jsonFixture)
-    run(
-      '.',
-      jsonFixtureToString,
-      { nullInput: true }
-    )
-    .then((result) => {
-      expect(result).to.be.equal(jsonFixtureToString)
-      done()
-    })
-    .catch((err) => {
-      done(err)
-    })
+  it('should run the filter inline with null-input', () => {
+    return expect(
+      run('.', jsonFixtureToString, { nullInput: true })
+    ).to.eventually.become(jsonFixtureToString)
   })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,33 @@
+import chai, { expect } from 'chai'
+import chaiAsPromised from 'chai-as-promised'
+chai.use(chaiAsPromised)
+import path from 'path'
+import jsonFixture from './fixtures/1.json'
+import { isAJsonPath, isAJson } from '../src/utils'
+
+const jsonFixtureToString = JSON.stringify(jsonFixture)
+const FIXTURES_PATH = path.join(__dirname, 'fixtures')
+const jsonPathFixture = path.join(FIXTURES_PATH, '1.json')
+const jsPathFixture = path.join(FIXTURES_PATH, '1.js')
+
+describe('path', () => {
+  describe('#isAJsonPath', () => {
+    it('should return true when u give a jsonpath', () => {
+      expect(isAJsonPath(jsonPathFixture)).to.be.equal(true)
+    })
+
+    it('should return false when u give a non-jsonpath', () => {
+      expect(isAJsonPath(jsPathFixture)).to.be.equal(false)
+    })
+  })
+
+  describe('#isAJson', () => {
+    it('should return true when u give a json', () => {
+      expect(isAJson(jsonFixtureToString)).to.be.equal(true)
+    })
+
+    it('should return false when u give a non-json', () => {
+      expect(isAJson('lola')).to.be.equal(false)
+    })
+  })
+})


### PR DESCRIPTION
Depends on https://github.com/davesnx/node-jq/pull/5

Here I'm only splitting up the utils from the `jq.js` entry point and doing the same with the tests.
Also, I remove the assertions of chai (😢 ) and replace it with the `chai-as-promised` interface, using `eventually` that works fine with the async operations. [Source](https://github.com/domenic/chai-as-promised)

Also adding a *FIXME* comment on top of `isAJson()` that does a try catch trying to parse the json, it's pretty slow we can replace it checking the keys of the object or whatever.